### PR TITLE
Removed references to jQuery 3 - leaving 1.11.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,25 +58,3 @@ Install the AWS Toolkit for VS 2017 - https://aws.amazon.com/visualstudio/
 ## Exploitation Demos
 
 See the `docs` folder
-
-
-# TODO
-
-
-## Immediate:
-
-* Make it more easily deployable into Cloud Services (MS have lots of nice tools to help)
-* Test on Greenlight.
-
-## Ongoing:
-* Add a couple of 'legacy' ASPX pages so that Greenlight can be demoed on pages (it doesn't work on CSHTML) 
-* DOM based XSS to demonstrate Javascript-oriented flaw remedation
-* SourceClear/SCA demonstration through use of outdated/flaws 3rd party components
-
-## Missing from here, but in Verademo
-* cwe-113-http-response-splitting
-* cwe-134-format-string-injection
-* cwe-384-session-fixation
-
-## Specific to .NET - possibly to implement (but bear in mind resourcing on supporting course notes)
-* cwe-80 based on inadvertant exposure of public method in a controller. All controller methods are publicly accessible via get/set so look at converting to private/protected or use the [NonAction] attribute

--- a/VeraDemoNet/VeraDemoNet.csproj
+++ b/VeraDemoNet/VeraDemoNet.csproj
@@ -273,18 +273,7 @@
     </Content>
     <None Include="Properties\PublishProfiles\FolderProfile.pubxml" />
     <None Include="Properties\PublishProfiles\VeraDemoNet20181012063617 - Web Deploy.pubxml" />
-    <None Include="Scripts\jquery-3.3.1.intellisense.js" />
     <Content Include="Scripts\jquery-1.11.2.min.js" />
-    <Content Include="Scripts\jquery-3.3.1.js" />
-    <Content Include="Scripts\jquery-3.3.1.min.js" />
-    <Content Include="Scripts\jquery-3.3.1.slim.js" />
-    <Content Include="Scripts\jquery-3.3.1.slim.min.js" />
-    <None Include="Scripts\jquery.validate-vsdoc.js" />
-    <Content Include="Scripts\jquery.validate.js" />
-    <Content Include="Scripts\jquery.validate.min.js" />
-    <Content Include="Scripts\jquery.validate.unobtrusive.js" />
-    <Content Include="Scripts\jquery.validate.unobtrusive.min.js" />
-    <Content Include="Scripts\modernizr-2.8.3.js" />
     <Content Include="Web.config" />
     <Content Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
@@ -322,8 +311,6 @@
     <Content Include="Content\bootstrap-theme.min.css.map" />
     <Content Include="Content\bootstrap-theme.css.map" />
     <None Include="packages.config" />
-    <Content Include="Scripts\jquery-3.3.1.slim.min.map" />
-    <Content Include="Scripts\jquery-3.3.1.min.map" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/VeraDemoNet/packages.config
+++ b/VeraDemoNet/packages.config
@@ -3,7 +3,7 @@
   <package id="Antlr" version="3.5.0.2" targetFramework="net461" />
   <package id="bootstrap" version="3.3.7" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
-  <package id="jQuery" version="3.3.1" targetFramework="net461" />
+  <package id="jQuery" version="1.11.2" targetFramework="net461" />
   <package id="jQuery.Validation" version="1.17.0" targetFramework="net461" />
   <package id="log4net" version="2.0.8" targetFramework="net461" />
   <package id="Microsoft.ApplicationInsights" version="2.5.1" targetFramework="net461" />


### PR DESCRIPTION
References to jQuery 3 weren't needed as pages use jQuery 1. 