### PR TITLE
Removed to map files from the project. 

### DIFF
--- a/VeraDemoNet/VeraDemoNet.csproj
+++ b/VeraDemoNet/VeraDemoNet.csproj
@@ -306,9 +306,7 @@
     <Content Include="fonts\glyphicons-halflings-regular.woff" />
     <Content Include="fonts\glyphicons-halflings-regular.ttf" />
     <Content Include="fonts\glyphicons-halflings-regular.eot" />
-    <Content Include="Content\bootstrap.min.css.map" />
     <Content Include="Content\bootstrap.css.map" />
-    <Content Include="Content\bootstrap-theme.min.css.map" />
     <Content Include="Content\bootstrap-theme.css.map" />
     <None Include="packages.config" />
   </ItemGroup>


### PR DESCRIPTION
The CSS Map files were not necessary. The files had been removed but their link in the csproj still remained.